### PR TITLE
Conflicto en el árbol de dependencias de npm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ Al principio de cada entrada se lista la versión de la biblioteca de sisdai-css
 sisdai-componentes con la que la versión indicada de sisdai-graficas es
 compatible y tiene instalada.
 
+## [6.8.2] - 2025-10-06
+
+### Cambiado (Changed)
+
+- Se corrige versión de sisdai-componentes a v4.14.1
+- Se corrige versión de sisdai-css a v1.10.2
+
+### Arreglado (Fixed)
+
+- Lo anterior arregla el conflicto en el árbol de dependencias de npm
+
 ## [6.8.1] - 2025-09-01
 
 ### Arreglado (Fixed)

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "d3-sankey": "^0.12.3"
   },
   "peerDependencies": {
-    "@centrogeomx/sisdai-componentes": "^4.12.5",
-    "@centrogeomx/sisdai-css": "github:CentroGeo/sisdai-css#v1.9.1",
+    "@centrogeomx/sisdai-componentes": "^4.14.1",
+    "@centrogeomx/sisdai-css": "^1.9.1",
     "pinia": "^3.0.1",
     "vue": "^3.5.13"
   },

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "peerDependencies": {
     "@centrogeomx/sisdai-componentes": "^4.14.1",
-    "@centrogeomx/sisdai-css": "^1.9.1",
+    "@centrogeomx/sisdai-css": "^1.10.2",
     "pinia": "^3.0.1",
     "vue": "^3.5.13"
   },


### PR DESCRIPTION
### Cambiado (Changed)

- Se corrige versión de sisdai-componentes a v4.14.1
- Se corrige versión de sisdai-css a v1.10.2

### Arreglado (Fixed)

- Lo anterior arregla el conflicto en el árbol de dependencias de npm